### PR TITLE
remove @inline, so that build_subA! does not error on Julia LTS test

### DIFF
--- a/src/RationalVectorFitting.jl
+++ b/src/RationalVectorFitting.jl
@@ -86,7 +86,7 @@ function pole_identification(s, f, poles, relaxed)
     Nc = (ndims(f) == 1) ? 1 : size(f)[2]
     A_sys = Array{Float64}(undef, (Nc * Nres), Nres)
     b_sys = zeros(Nc * Nres)
-    @inline build_subA!(A1_cplx, s, poles)  # left block
+    build_subA!(A1_cplx, s, poles)  # left block
     for n = 1:Nc
         A1_cplx[1:Ns, (Np+3):Ncols] .= -f[1:Ns, n] .* A1_cplx[1:Ns, 1:Nres]  # right block
         A1_reim[1:Ns, :] .= real(A1_cplx)
@@ -164,7 +164,7 @@ function residue_identification(s, f, poles)
     A_sys = Array{Float64}(undef, Nrows, Ncols)
     X_sys = Array{Float64}(undef, Ncols, Nc)
 
-    @inline build_subA!(A1_cplx, s, poles)
+    build_subA!(A1_cplx, s, poles)
     A_sys[1:Ns, :] .= real(A1_cplx)
     A_sys[(Ns+1):end, :] .= imag(A1_cplx)
     X_sys = A_sys \ [real(f); imag(f)]


### PR DESCRIPTION
<!--
Thanks for making a pull request to RationalVectorFitting.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines and abide by the code of conduct.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/pedrohnv/RationalVectorFitting.jl/blob/main/docs/src/90-contributing.md)

- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
